### PR TITLE
fixed failed release workflow by adding required permissions for issu…

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -2,6 +2,8 @@ name: Release (create git tag) on merge to main
 
 permissions:
   contents: write
+  issues: write
+  pull-requests: write
 
 on:
   push:


### PR DESCRIPTION
…es and pull-requests

<!--
PR template for Sales Assistant Backend
This template reminds contributors/maintainers to add the release label required by the release workflow.
-->

# Pull Request

Short summary (one or two lines):

Describe the change and why it is needed.

## Checklist

- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation if needed
- [ ] I have added a changelog entry if this change affects public behavior

IMPORTANT: If this PR should trigger a release when merged to `master`, add one of the following labels to the PR (maintainers may add the label before merge):

- `major` — for breaking changes (bump MAJOR)
- `minor` — for new backward-compatible features (bump MINOR)
- `patch` — for bugfixes or small changes (bump PATCH)

The release workflow requires an explicit release label. If no label is present the release job will fail. If you are unsure which label to use, ask in the PR.

## Related issues

Links to issues, if any.
