### PR TITLE
avoid installing scoped auto plugins, which failed due to registry/auth

### DIFF
--- a/.autorc.json
+++ b/.autorc.json
@@ -1,7 +1,7 @@
 {
   "plugins": [
     [
-      "@auto-it/labels",
+      "labels",
       {
         "labels": {
           "patch": { "release": "patch" },
@@ -10,18 +10,12 @@
         }
       }
     ],
-    "@auto-it/release-notes",
-    [
-      "@auto-it/github",
-      {
-        "release": true
-      }
-    ],
-    [
-      "@auto-it/npm",
-      {
-        "publish": false
-      }
-    ]
-  ]
+    "release-notes"
+  ],
+  "github": {
+    "release": true
+  },
+  "npm": {
+    "publish": false
+  }
 }

--- a/.github/workflows/release-with-auto.yml
+++ b/.github/workflows/release-with-auto.yml
@@ -33,11 +33,13 @@ jobs:
           # Install project dependencies so npx auto uses the repo's version if present
           npm ci
 
-      - name: Install auto plugins (labels, release-notes, github, npm)
+      - name: Install pinned auto CLI
         run: |
           set -euo pipefail
-          # Install the @auto-it plugin packages so auto can load them reliably
-          npm install --no-save @auto-it/labels @auto-it/release-notes @auto-it/github @auto-it/npm
+          # Install a pinned auto version to avoid resolving scoped plugin packages
+          # or relying on external registry auth. Pin to 10.x for compatibility with
+          # existing .autorc (older format).
+          npm install --no-save auto@10
 
       - name: Choose token for pushing tags/commits
         id: choose-token


### PR DESCRIPTION
<!--
PR template for Sales Assistant Backend
This template reminds contributors/maintainers to add the release label required by the release workflow.
-->

# Pull Request

Short summary (one or two lines):

Describe the change and why it is needed.

## Checklist

- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation if needed
- [ ] I have added a changelog entry if this change affects public behavior

IMPORTANT: If this PR should trigger a release when merged to `master`, add one of the following labels to the PR (maintainers may add the label before merge):

- `major` — for breaking changes (bump MAJOR)
- `minor` — for new backward-compatible features (bump MINOR)
- `patch` — for bugfixes or small changes (bump PATCH)

The release workflow requires an explicit release label. If no label is present the release job will fail. If you are unsure which label to use, ask in the PR.

## Related issues

Links to issues, if any.
