### PR TITLE
fix: cashflow status sync & optimistic update, settings API consolida…

### DIFF
--- a/src/components/cashflow/CashflowHistoryTable.tsx
+++ b/src/components/cashflow/CashflowHistoryTable.tsx
@@ -17,7 +17,7 @@ import {
   patchCashflowEntryStatus,
   type CashflowEntry,
 } from "@/lib/api";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMockableQuery } from "@/hooks/useMockableQuery";
 import { mockContracts } from "@/lib/mockData";
 import { asArray } from "@/lib/safe";
@@ -88,11 +88,29 @@ export function CashflowHistoryTable({
   type RangeFilter = "all" | "30" | "90" | "365";
 
   const [range, setRange] = useState<RangeFilter>("30");
-  // Optimistic local status overrides: entryId -> "overdue" | "confirmed"
-  const [statusOverrides, setStatusOverrides] = useState<
-    Record<number, "overdue" | "confirmed">
-  >({});
   const queryClient = useQueryClient();
+
+  // Shared status overrides stored in React Query cache so all
+  // CashflowHistoryTable instances (main page + detail drawer) stay in sync.
+  const OVERRIDES_KEY = ["cashflow-status-overrides"] as const;
+  const { data: statusOverrides = {} } = useQuery<
+    Record<number, "overdue" | "confirmed">
+  >({
+    queryKey: OVERRIDES_KEY,
+    queryFn: () => ({}),
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+  const setStatusOverrides = (
+    updater: (
+      prev: Record<number, "overdue" | "confirmed">,
+    ) => Record<number, "overdue" | "confirmed">,
+  ) => {
+    queryClient.setQueryData<Record<number, "overdue" | "confirmed">>(
+      OVERRIDES_KEY,
+      (prev = {}) => updater(prev),
+    );
+  };
 
   useEffect(() => {
     setRange("30");
@@ -252,14 +270,10 @@ export function CashflowHistoryTable({
                     }));
                     try {
                       await patchCashflowEntryStatus(e.id, next);
-                      // Clear override — let fresh backend data take over
-                      setStatusOverrides((prev) => {
-                        const copy = { ...prev };
-                        delete copy[e.id];
-                        return copy;
-                      });
-                      // Invalidate all contract query variants so both the list
-                      // view and the detail view reflect the updated status.
+                      // Do NOT clear the override — compact mode doesn't return
+                      // cashflow statuses, so clearing it would cause a blink back
+                      // to the old value while the refetch is in flight.
+                      // The override persists as the source of truth until unmount.
                       queryClient.invalidateQueries({
                         queryKey: queryKeys.contractsList({ compact: true }),
                       });

--- a/src/components/sales-process/SalesProcessTable.tsx
+++ b/src/components/sales-process/SalesProcessTable.tsx
@@ -87,7 +87,7 @@ export function SalesProcessTable({
         </div>
       </CardHeader>
       <CardContent>
-        <Table>
+        <Table className="[&_th]:px-3 [&_td]:px-3">
           <TableHeader>
             <TableRow>
               <TableHead>Kunde</TableHead>
@@ -295,7 +295,7 @@ export function SalesProcessTable({
                     {entry.revenue ? `€${entry.revenue.toLocaleString()}` : "-"}
                   </TableCell>
                   <TableCell>
-                    <div className="flex flex-col items-start gap-1">
+                    <div className="flex flex-row items-center gap-1.5 flex-wrap">
                       {entry.stage === SALES_STAGE.INITIAL_CONTACT && (
                         <Button size="sm" onClick={() => onPlanFollowUp(entry)}>
                           Zweitgespräch planen

--- a/src/components/sales-process/SalesProcessWorkflowForm.tsx
+++ b/src/components/sales-process/SalesProcessWorkflowForm.tsx
@@ -128,12 +128,7 @@ export function SalesProcessWorkflowForm({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="email">
-                Email{" "}
-                <span className="text-muted-foreground font-normal">
-                  (oder Telefon *)
-                </span>
-              </Label>
+              <Label htmlFor="email">Email *</Label>
               <Input
                 id="email"
                 type="email"
@@ -147,12 +142,7 @@ export function SalesProcessWorkflowForm({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="phone">
-                Telefon{" "}
-                <span className="text-muted-foreground font-normal">
-                  (oder Email *)
-                </span>
-              </Label>
+              <Label htmlFor="phone">Telefon</Label>
               <Input
                 id="phone"
                 value={formData.phone}
@@ -165,7 +155,7 @@ export function SalesProcessWorkflowForm({
             </div>
 
             <div className="space-y-2">
-              <Label>Datum des Erstgesprächs</Label>
+              <Label>Datum des Erstgesprächs *</Label>
               <Popover>
                 <PopoverTrigger asChild>
                   <Button
@@ -254,7 +244,8 @@ export function SalesProcessWorkflowForm({
                 disabled={
                   !formData.name ||
                   !formData.source ||
-                  !(formData.email.trim() || formData.phone.trim()) ||
+                  !formData.email.trim() ||
+                  !formData.erstgespraechDate ||
                   isStartPending
                 }
               >
@@ -457,7 +448,7 @@ export function SalesProcessWorkflowForm({
             {formData.abschluss && (
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4 p-4 bg-success/10 rounded-lg">
                 <div className="space-y-2">
-                  <Label>Umsatz (€)</Label>
+                  <Label>Umsatz (€) *</Label>
                   <Input
                     type="number"
                     value={formData.revenue}
@@ -470,7 +461,7 @@ export function SalesProcessWorkflowForm({
                 </div>
 
                 <div className="space-y-2">
-                  <Label>Vertragsdauer (Monate)</Label>
+                  <Label>Vertragsdauer (Monate) *</Label>
                   <Select
                     value={formData.contractDuration ?? ""}
                     onValueChange={(value) =>
@@ -490,7 +481,7 @@ export function SalesProcessWorkflowForm({
                 </div>
 
                 <div className="space-y-2">
-                  <Label>Startdatum</Label>
+                  <Label>Startdatum *</Label>
                   <Popover>
                     <PopoverTrigger asChild>
                       <Button
@@ -526,7 +517,7 @@ export function SalesProcessWorkflowForm({
                 </div>
 
                 <div className="space-y-2">
-                  <Label>Zahlungsfrequenz</Label>
+                  <Label>Zahlungsfrequenz *</Label>
                   <Select
                     value={formData.contractFrequency ?? ""}
                     onValueChange={(value) =>
@@ -558,7 +549,7 @@ export function SalesProcessWorkflowForm({
                 </div>
 
                 <div className="space-y-2">
-                  <Label>Abschlussdatum</Label>
+                  <Label>Abschlussdatum *</Label>
                   <Popover>
                     <PopoverTrigger asChild>
                       <Button
@@ -638,12 +629,7 @@ export function SalesProcessWorkflowForm({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="email-zweit">
-                Email{" "}
-                <span className="text-muted-foreground font-normal">
-                  (oder Telefon *)
-                </span>
-              </Label>
+              <Label htmlFor="email-zweit">Email *</Label>
               <Input
                 id="email-zweit"
                 type="email"
@@ -657,12 +643,7 @@ export function SalesProcessWorkflowForm({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="phone-zweit">
-                Telefon{" "}
-                <span className="text-muted-foreground font-normal">
-                  (oder Email *)
-                </span>
-              </Label>
+              <Label htmlFor="phone-zweit">Telefon</Label>
               <Input
                 id="phone-zweit"
                 value={formData.phone}
@@ -764,7 +745,7 @@ export function SalesProcessWorkflowForm({
                 disabled={
                   !formData.name ||
                   !formData.source ||
-                  !(formData.email.trim() || formData.phone.trim()) ||
+                  !formData.email.trim() ||
                   !formData.zweitgespraechDate ||
                   isStartPending
                 }

--- a/src/helpers/error.ts
+++ b/src/helpers/error.ts
@@ -14,7 +14,19 @@ export function extractErrorMessage(err: unknown): string {
       message?: string;
     };
 
+    const status = axiosErr.response?.status;
     const data = axiosErr.response?.data;
+
+    // 409 Conflict — duplicate resource (e.g. email already in use)
+    if (status === 409) {
+      if (typeof data === "string" && data.trim()) return data;
+      if (typeof data === "object" && data !== null) {
+        const d = data as Record<string, unknown>;
+        const msg = d.error ?? d.message ?? d.detail;
+        if (typeof msg === "string" && msg.trim()) return msg;
+      }
+      return "Dieser Eintrag existiert bereits (Konflikt).";
+    }
 
     if (typeof data === "string") return data;
 

--- a/src/pages/SalesProcess.tsx
+++ b/src/pages/SalesProcess.tsx
@@ -267,7 +267,8 @@ export default function SalesProcessView() {
     !!formData.contractFrequency &&
     ["monthly", "bi-monthly", "quarterly", "bi-yearly", "one-time"].includes(
       formData.contractFrequency,
-    );
+    ) &&
+    !!formData.completedAt;
 
   const canSubmit = formData.abschluss !== true || isContractValid;
 
@@ -400,7 +401,7 @@ export default function SalesProcessView() {
       } catch (err) {
         toast({
           title: "Fehler beim Speichern",
-          description: err instanceof Error ? err.message : String(err),
+          description: extractErrorMessage(err),
           variant: "destructive",
         });
       }
@@ -425,7 +426,7 @@ export default function SalesProcessView() {
       } catch (err) {
         toast({
           title: "Fehler beim Speichern",
-          description: err instanceof Error ? err.message : String(err),
+          description: extractErrorMessage(err),
           variant: "destructive",
         });
       }
@@ -475,7 +476,7 @@ export default function SalesProcessView() {
       } catch (err) {
         toast({
           title: "Fehler beim Speichern",
-          description: err instanceof Error ? err.message : String(err),
+          description: extractErrorMessage(err),
           variant: "destructive",
         });
       }
@@ -716,7 +717,7 @@ export default function SalesProcessView() {
     } catch (err) {
       toast({
         title: "Fehler beim Speichern",
-        description: err instanceof Error ? err.message : String(err),
+        description: extractErrorMessage(err),
         variant: "destructive",
       });
     }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -46,26 +46,19 @@ const parseEmailRecipients = (value?: string | null) => {
   return normalizeEmails(raw.split(/[\n,;]+/));
 };
 
-// Mock data references (defined outside component to avoid re-render loops)
-const MOCK_MONTHS: Setting = {
-  key: "potential_months",
-  value_numeric: 6,
-  value_text: null,
-};
-const MOCK_FLAT: Setting = {
-  key: "avg_revenue_per_contract",
-  value_numeric: 600,
-  value_text: null,
-};
-const MOCK_NOTIFY_EMAIL: Setting = {
-  key: "new_contract_notify_email",
-  value_numeric: null,
-  value_text: "",
-};
+const MOCK_SETTINGS: Setting[] = [
+  { key: "potential_months", value_numeric: 6, value_text: null },
+  { key: "avg_revenue_per_contract", value_numeric: 600, value_text: null },
+  { key: "new_contract_notify_email", value_numeric: null, value_text: "" },
+];
 
-const fetchSetting = async (key: string): Promise<Setting> => {
-  const { data } = await api.get(`/settings/${key}`);
-  return data;
+const fetchAllSettings = async (): Promise<Setting[]> => {
+  const { data } = await api.get("/settings");
+  return Array.isArray(data)
+    ? data
+    : Object.entries(data).map(
+        ([key, val]: [string, unknown]) => val as Setting,
+      );
 };
 
 const updateNumericSetting = async (key: string, value: number) => {
@@ -79,23 +72,21 @@ const updateTextSetting = async (key: string, value: string) => {
 export default function Settings() {
   const qc = useQueryClient();
 
-  const { data: monthsSetting, isLoading: lMonths } = useMockableQuery({
-    queryKey: queryKeys.setting("potential_months"),
-    queryFn: () => fetchSetting("potential_months"),
-    mockData: MOCK_MONTHS,
+  const { data: allSettings = [], isLoading: lSettings } = useMockableQuery({
+    queryKey: queryKeys.settings,
+    queryFn: fetchAllSettings,
+    mockData: MOCK_SETTINGS,
   });
 
-  const { data: flatSetting, isLoading: lFlat } = useMockableQuery({
-    queryKey: queryKeys.setting("avg_revenue_per_contract"),
-    queryFn: () => fetchSetting("avg_revenue_per_contract"),
-    mockData: MOCK_FLAT,
-  });
-
-  const { data: notifyEmailSetting } = useMockableQuery({
-    queryKey: queryKeys.setting("new_contract_notify_email"),
-    queryFn: () => fetchSetting("new_contract_notify_email"),
-    mockData: MOCK_NOTIFY_EMAIL,
-  });
+  const monthsSetting = allSettings.find((s) => s.key === "potential_months");
+  const flatSetting = allSettings.find(
+    (s) => s.key === "avg_revenue_per_contract",
+  );
+  const notifyEmailSetting = allSettings.find(
+    (s) => s.key === "new_contract_notify_email",
+  );
+  const lMonths = lSettings;
+  const lFlat = lSettings;
 
   const [months, setMonths] = useState("");
   const [flatEur, setFlatEur] = useState("");


### PR DESCRIPTION
…tion

- Store cashflow status overrides in React Query cache (shared across all CashflowHistoryTable instances) so toggling in detail view updates main page and vice versa
- Remove override clear-on-success to prevent blink caused by compact mode not returning cashflow entries in refetch response
- Fix cache invalidation to cover both contractsList(compact) and contract(id) keys so all active queries refetch after status PATCH
- Replace 3 parallel GET /settings/:key calls with single GET /api/settings on Settings page, saving 2 round-trips per load
- make fields in sales process form obligatory

<!--
PR template for Sales Assistant Backend
This template reminds contributors/maintainers to add the release label required by the release workflow.
-->

# Pull Request

Short summary (one or two lines):

Describe the change and why it is needed.

## Checklist

- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation if needed
- [ ] I have added a changelog entry if this change affects public behavior

IMPORTANT: If this PR should trigger a release when merged to `master`, add one of the following labels to the PR (maintainers may add the label before merge):

- `major` — for breaking changes (bump MAJOR)
- `minor` — for new backward-compatible features (bump MINOR)
- `patch` — for bugfixes or small changes (bump PATCH)

The release workflow requires an explicit release label. If no label is present the release job will fail. If you are unsure which label to use, ask in the PR.

## Related issues

Links to issues, if any.
