### PR TITLE
feat(sales): include stage_id in sales process updates

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -203,6 +203,7 @@ export type SalesProcessUpdateRequest = {
   follow_up_date?: string | null;
   source?: "organic" | "paid" | null;
   source_stage_id?: number | null;
+  stage_id?: number | null;
   closed?: boolean | null;
   revenue?: number | null;
   contract_duration_months?: number;
@@ -535,6 +536,17 @@ export const deleteStageParticipant = async (
 ): Promise<void> => {
   await api.delete(`/stages/${stageId}/participants/${participantId}`);
 };
+
+export interface StageParticipantUI {
+  id: number;
+  stage_id: number;
+  name: string;
+  email?: string | null;
+  phone?: string | null;
+  client_id?: number | null;
+  lead_id?: number | null;
+  attended: boolean;
+}
 
 /* Stage participants */
 export interface StageParticipant {

--- a/src/pages/SalesProcess.tsx
+++ b/src/pages/SalesProcess.tsx
@@ -446,6 +446,7 @@ export default function SalesProcessView() {
         follow_up_result: formData.zweitgespraechResult ?? true,
         closed: formData.abschluss ?? null,
         revenue: revenueNum,
+        stage_id: formData.stageId ?? null,
         completed_at: formData.completedAt
           ? format(formData.completedAt, "yyyy-MM-dd")
           : undefined,
@@ -570,6 +571,7 @@ export default function SalesProcessView() {
       name: entry.client_name,
       salesProcessId: entry.id,
       clientId: entry.client_id,
+      stageId: entry.stage_id ?? null,
       zweitgespraechResult: defaultResult,
       zweitgespraechDate: followUpDate,
     }));
@@ -583,6 +585,7 @@ export default function SalesProcessView() {
       name: entry.client_name,
       salesProcessId: entry.id,
       clientId: entry.client_id,
+      stageId: entry.stage_id ?? null,
       zweitgespraechResult: true,
       abschluss: null,
       zweitgespraechDate: parseIsoToLocal(entry.follow_up_date),
@@ -637,6 +640,7 @@ export default function SalesProcessView() {
                 : undefined,
             follow_up_result: payload.follow_up_result,
             completed_at: payload.completed_at || undefined,
+            stage_id: payload.source_stage_id ?? null,
           },
         }),
         updateClient(entry.client_id, clientPayload),

--- a/src/pages/Stages.tsx
+++ b/src/pages/Stages.tsx
@@ -52,9 +52,8 @@ import {
   getStageParticipants,
   Stage,
   StageParticipant,
-  StageParticipantUI,
 } from "@/lib/api";
-import type { AddStageParticipantRequest } from "@/lib/api";
+import type { AddStageParticipantRequest, StageParticipantUI } from "@/lib/api";
 import { MetricChip } from "@/components/MetricChip";
 import {
   ParticipantForm,


### PR DESCRIPTION
- Add `stage_id` to the sales process PATCH request type
- Send and hydrate `stage_id` in Sales Process form mapping/update flows
- Export `StageParticipantUI` from API types and clean up type-only imports in Stages page

<!--
PR template for Sales Assistant Backend
This template reminds contributors/maintainers to add the release label required by the release workflow.
-->

# Pull Request

Short summary (one or two lines):

Describe the change and why it is needed.

## Checklist

- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation if needed

IMPORTANT: If this PR should trigger a release when merged to `master`, add one of the following labels to the PR (maintainers may add the label before merge):

- `major` — for breaking changes (bump MAJOR)
- `minor` — for new backward-compatible features (bump MINOR)
- `patch` — for bugfixes or small changes (bump PATCH)

The release workflow requires an explicit release label. If no label is present the release job will fail. If you are unsure which label to use, ask in the PR.

## Related issues

Links to issues, if any.
