### PR TITLE
fix: disable Laufzeit field; use end_date_override in table; prevent save when form unchanged

### DIFF
--- a/src/components/contract/ContractEditModal.tsx
+++ b/src/components/contract/ContractEditModal.tsx
@@ -107,6 +107,11 @@ export function ContractEditModal({
   const durationNum = Number(duration) || 0;
   const revenueModeLabel = "Brutto";
 
+  const isFormDirty =
+    startDate !== toDateOnly(contract?.start_date) ||
+    frequency !== (contract?.payment_frequency ?? "monthly") ||
+    revenueDirty;
+
   const MAX_DURATION = 120;
   const MIN_DURATION = 0;
   const MAX_REVENUE = 1_000_000;
@@ -413,9 +418,9 @@ export function ContractEditModal({
         )}
         <DialogFooter className="mt-6">
           <Button variant="outline" onClick={onClose} disabled={isSubmitting}>
-            Abbrechen
+            {isFormDirty ? "Abbrechen" : "Schließen"}
           </Button>
-          <Button onClick={handleSubmit} disabled={isSubmitting}>
+          <Button onClick={handleSubmit} disabled={isSubmitting || !isFormDirty}>
             {isSubmitting ? "Speichern..." : "Speichern"}
           </Button>
         </DialogFooter>

--- a/src/helpers/contract.ts
+++ b/src/helpers/contract.ts
@@ -36,11 +36,14 @@ export function addMonthsIso(iso: string, m: number): string {
 export function getContractEndDate(contract: {
   start_date?: string | null;
   end_date?: string | null;
+  end_date_override?: string | null;
   duration_months?: number | null;
 }): Date | null {
   const start = toDateStartOfDay(contract.start_date ?? null);
+  const endOverride = toDateStartOfDay(contract.end_date_override ?? null);
   const endFromServer = toDateStartOfDay(contract.end_date ?? null);
 
+  if (endOverride) return endOverride;
   if (endFromServer) return endFromServer;
   if (!start || typeof contract.duration_months !== "number") return null;
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -397,6 +397,7 @@ export interface Contract {
   created_at: string;
   start_date: string;
   end_date?: string | null;
+  end_date_override?: string | null;
   duration_months: number;
   revenue_total: number;
   payment_frequency: string;


### PR DESCRIPTION
fix: disable Laufzeit field; use end_date_override in table; prevent save when form unchanged

<!--
PR template for Sales Assistant Backend
This template reminds contributors/maintainers to add the release label required by the release workflow.
-->

# Pull Request

Short summary (one or two lines):

Describe the change and why it is needed.

## Checklist

- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation if needed

IMPORTANT: If this PR should trigger a release when merged to `master`, add one of the following labels to the PR (maintainers may add the label before merge):

- `major` — for breaking changes (bump MAJOR)
- `minor` — for new backward-compatible features (bump MINOR)
- `patch` — for bugfixes or small changes (bump PATCH)

The release workflow requires an explicit release label. If no label is present the release job will fail. If you are unsure which label to use, ask in the PR.

## Related issues

Links to issues, if any.
